### PR TITLE
Rename proto_dict converter function

### DIFF
--- a/client.py
+++ b/client.py
@@ -2,7 +2,7 @@ from ctrader_open_api import Client, Protobuf, TcpProtocol, EndPoints
 from ctrader_open_api.messages.OpenApiMessages_pb2 import *
 from ctrader_open_api.messages.OpenApiModelMessages_pb2 import *
 from twisted.internet import reactor
-from converters import proto_dict_connert
+from converters import proto_dict_convert
 import calendar
 import datetime
 
@@ -90,7 +90,7 @@ class TraderClient:
                 self.account_authorized = True
 
             if message.payloadType == ProtoOAGetTrendbarsRes().payloadType:
-                trendbars = proto_dict_connert(extracted_message.trendbar)
+                trendbars = proto_dict_convert(extracted_message.trendbar)
                 print("\n--- Trendbars converted to dict list ---")
                 print(trendbars)
                 print("--- CSV has been saved as trentbars_data.csv ---")

--- a/converters.py
+++ b/converters.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-def proto_dict_connert(trentbars):
+def proto_dict_convert(trentbars):
     trentbars_list = [
         {
             "volume": tb.volume,


### PR DESCRIPTION
## Summary
- rename `proto_dict_connert` to `proto_dict_convert`
- update all imports and call sites

## Testing
- `python -m py_compile converters.py client.py run.py access_token_get.py candles_graf.py first_half_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_68669f6d90a48329b78b4daacda8053a